### PR TITLE
feat(js): initial implementation of caching via redis

### DIFF
--- a/dbs/index.js
+++ b/dbs/index.js
@@ -1,0 +1,4 @@
+import { connectMongo } from './mongo.js'
+import { connectRedis } from './redis.js'
+
+export { connectMongo, connectRedis }

--- a/dbs/redis.js
+++ b/dbs/redis.js
@@ -1,0 +1,26 @@
+import { createClient } from 'redis'
+
+let redis = null
+
+async function connectRedis() {
+  if (redis) return redis
+
+  const {REDIS_URL} = process.env
+  if (!REDIS_URL) {
+    throw new Error('REDIS_URL is not defined in environment variables')
+  }
+
+  const client = createClient({url: REDIS_URL})
+  client.on('error', (err) => console.error('Redis Client Error:', err))
+  client.on('connect', () => console.log(`Connected to Redis @ ${REDIS_URL}`))
+
+  try {
+    await client.connect()
+    redis = client
+  } catch (error) {
+    console.error(`Failed to connect to Redis @ ${REDIS_URL}:`, error)
+    throw error
+  }
+}
+
+export { connectRedis, redis }

--- a/express.js
+++ b/express.js
@@ -1,7 +1,8 @@
 import dotenv from 'dotenv'
 import express from 'express'
+import { connectMongo, connectRedis } from './dbs/index.js'
 import router from './routes/router.js'
-import { connectMongo } from './dbs/mongo.js'
+
 
 dotenv.config()
 
@@ -11,6 +12,7 @@ if (!PORT) {
 }
 
 await connectMongo()
+await connectRedis()
 
 const app = express()
 app.use(express.json())

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,15 @@
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "luxon": "^3.6.1",
-        "mongoose": "^8.12.1"
+        "mongoose": "^8.12.1",
+        "redis": "^5.9.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
         "@types/express": "^5.0.1",
         "@types/mongoose": "^5.11.96",
         "@types/node": "^22.14.1",
+        "@types/redis": "^4.0.10",
         "eslint": "^9.24.0",
         "nodemon": "^3.1.9",
         "ts-node": "^10.9.2",
@@ -272,6 +274,66 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.9.0.tgz",
+      "integrity": "sha512-W9D8yfKTWl4tP8lkC3MRYkMz4OfbuzE/W8iObe0jFgoRmgMfkBV+Vj38gvIqZPImtY0WB34YZkX3amYuQebvRQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.9.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.9.0.tgz",
+      "integrity": "sha512-EI0Ti5pojD2p7TmcS7RRa+AJVahdQvP/urpcSbK/K9Rlk6+dwMJTQ354pCNGCwfke8x4yKr5+iH85wcERSkwLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.9.0.tgz",
+      "integrity": "sha512-Bm2jjLYaXdUWPb9RaEywxnjmzw7dWKDZI4MS79mTWPV16R982jVWBj6lY2ZGelJbwxHtEVg4/FSVgYDkuO/MxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.9.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.9.0.tgz",
+      "integrity": "sha512-jdk2csmJ29DlpvCIb2ySjix2co14/0iwIT3C0I+7ZaToXgPbgBMB+zfEilSuncI2F9JcVxHki0YtLA0xX3VdpA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.9.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.9.0.tgz",
+      "integrity": "sha512-W6ILxcyOqhnI7ELKjJXOktIg3w4+aBHugDbVpgVLPZ+YDjObis1M0v7ZzwlpXhlpwsfePfipeSK+KWNuymk52w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.9.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -407,6 +469,16 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/redis": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-4.0.10.tgz",
+      "integrity": "sha512-7CLy5b5fzzEGVcOccgZjoMlNpPhX6d10jEeRy2YWbFuaMNrSPc9ExRsMYsd+0VxvEHucf4EWx24Ja7cSU1FGUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "redis": "*"
+      }
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
@@ -755,6 +827,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/color-convert": {
@@ -2234,6 +2315,22 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redis": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.9.0.tgz",
+      "integrity": "sha512-E8dQVLSyH6UE/C9darFuwq4usOPrqfZ1864kI4RFbr5Oj9ioB9qPF0oJMwX7s8mf6sPYrz84x/Dx1PGF3/0EaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@redis/bloom": "5.9.0",
+        "@redis/client": "5.9.0",
+        "@redis/json": "5.9.0",
+        "@redis/search": "5.9.0",
+        "@redis/time-series": "5.9.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/resolve-from": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "luxon": "^3.6.1",
-    "mongoose": "^8.12.1"
+    "mongoose": "^8.12.1",
+    "redis": "^5.9.0"
   },
   "description": "Barebones Time API Implementation",
   "devDependencies": {
@@ -12,6 +13,7 @@
     "@types/express": "^5.0.1",
     "@types/mongoose": "^5.11.96",
     "@types/node": "^22.14.1",
+    "@types/redis": "^4.0.10",
     "eslint": "^9.24.0",
     "nodemon": "^3.1.9",
     "ts-node": "^10.9.2",

--- a/routes/middleware.js
+++ b/routes/middleware.js
@@ -1,9 +1,25 @@
+import { DateTime } from 'luxon'
 import { isValidObjectId } from 'mongoose'
 
-export function validateId(req, res, next) {
+const REVIVE_FIELDS = ['created', 'time', 'updated']
+
+function convertTZ(entry, zone) {
+  const tz = decodeURIComponent(zone)
+  const local = DateTime.fromJSDate(entry.time).setZone(tz)
+  if (!local.isValid) return [null, {error: `Invalid TZ ${tz}`}]
+  return [{...entry, time: local.toISO()}]
+}
+
+function reviveDate(key, val) {
+  return REVIVE_FIELDS.includes(key) ? new Date(val) : val
+}
+
+function validateId(req, res, next) {
   const {id} = req.params
   if (!id || !isValidObjectId(id)) {
     return res.status(400).json({error: 'Invalid ID format'})
   }
   return next()
 }
+
+export { convertTZ, reviveDate, validateId }

--- a/routes/router.js
+++ b/routes/router.js
@@ -1,8 +1,11 @@
 import express from 'express'
 import { DateTime } from 'luxon'
 import { TimeEntry } from '../dbs/mongo.js'
-import { validateId } from './middleware.js'
+import { redis } from '../dbs/redis.js'
+import { convertTZ, reviveDate, validateId } from './middleware.js'
 
+const CACHE_TTL_SEC = 300
+const ERR_404_MSG = (id) => `Time entry [${id}] not found`
 const FIND_UPD_OPTS = {new: true, runValidators: true}
 
 const router = express.Router({ mergeParams: true })
@@ -14,7 +17,8 @@ router.delete('/:id', validateId, deleteTimeEntry)
 
 async function getAllTimeEntries(_, res) {
   try {
-    const entries = await TimeEntry.find()
+    const entries = await TimeEntry.find().lean()
+    console.debug('All (Mongo) entries returned')
     return res.json(entries)
   } catch (err) {
     return res.status(500).json({error: err.message})
@@ -25,15 +29,18 @@ async function getTimeEntryByID(req, res) {
   try {
     const {id} = req.params
     const {zone} = req.query
+    console.debug(`GET /time/${id}?zone=${zone || 'none'}`)
 
-    const entry = await TimeEntry.findById(id)
-    if (!entry) return res.status(404).json({error: 'Time entry not found'})
-    if (!zone) return res.json(entry)
+    const entry = await retrieveEntry(id)
+    if (!entry) return res.status(404).json({error: ERR_404_MSG(id)})
 
-    const tz = decodeURIComponent(zone)
-    const local = DateTime.fromJSDate(entry.time).setZone(tz)
-    if (!local.isValid) return res.status(400).json({error: `Invalid TZ ${tz}`})
-    return res.json({...entry.toObject(), time: local.toISO()})
+    await refreshEntry(entry)
+    if (!zone) return res.json(entry) // skip TZ conversion
+
+    const [result, err] = convertTZ(entry, zone)
+    if (err) return res.status(400).json(err)
+    console.debug(`Converted entry [${id}] returned, TZ: ${zone}`)
+    return res.json(result)
   } catch (err) {
     return res.status(500).json({error: err.message})
   }
@@ -44,7 +51,9 @@ async function createTimeEntry(req, res) {
     const {body} = req
 
     const new_entry = new TimeEntry(body)
-    const saved_ent = await new_entry.save()
+    const saved_ent = (await new_entry.save()).toObject()
+    await refreshEntry(saved_ent)
+    console.debug(`Time entry [${saved_ent._id.toString()}] successfully saved`)
     return res.status(201).json(saved_ent)
   } catch (err) {
     return res.status(400).json({error: err.message})
@@ -56,14 +65,18 @@ async function updateTimeEntry(req, res) {
     const {body} = req
     const {id} = req.params
     const {UTC} = req.query
-    if (UTC) {
+    if (UTC) { // overwrite `time` prop with Date in UTC before saving
       const utc = DateTime.fromISO(body.time, {zone: 'utc'})
       body.time = utc.toJSDate()
     }
 
     const updated = await TimeEntry.findByIdAndUpdate(id, body, FIND_UPD_OPTS)
-    if (!updated) return res.status(404).json({error: 'Time entry not found'})
-    return res.json(updated)
+    if (!updated) return res.status(404).json({error: ERR_404_MSG(id)})
+
+    const upd_obj = updated.toObject()
+    await refreshEntry(upd_obj)
+    console.debug(`Time entry [${upd_obj._id.toString()}] successfully updated`)
+    return res.json(upd_obj)
   } catch (err) {
     return res.status(400).json({error: err.message})
   }
@@ -74,11 +87,32 @@ async function deleteTimeEntry(req, res) {
 
   try {
     const deleted = await TimeEntry.findByIdAndDelete(id)
-    if (!deleted) return res.status(404).json({error: 'Time entry not found'})
-    return res.json({message: 'Time entry deleted successfully'})
+    if (!deleted) return res.status(404).json({error: ERR_404_MSG(id)})
+
+    const cache_key = `cache:${id}`
+    await redis.del(cache_key)
+    return res.json({message: `Time entry [${id}] successfully deleted`})
   } catch (err) {
     return res.status(500).json({error: err.message})
   }
+}
+
+async function refreshEntry(entry) {
+  const cache_key = `cache:${entry._id.toString()}`
+  return redis.setEx(cache_key, CACHE_TTL_SEC, JSON.stringify(entry))
+}
+
+async function retrieveEntry(id) {
+  const cached = await redis.get(`cache:${id}`)
+  if (cached) {
+    console.debug(`Cached entry [${id}] retrieved`)
+    return JSON.parse(cached, reviveDate)
+  }
+
+  const entry = await TimeEntry.findById(id).lean()
+  if (!entry) return null
+  console.debug(`Mongo entry [${id}] retrieved`)
+  return entry
 }
 
 export default router

--- a/server.js
+++ b/server.js
@@ -73,7 +73,7 @@ server.put('time/set/:id/:UTCtime', function (req, res, next) {
     return next()
 })
 
-server.del('time/delete/:id', function(req, res, next) {
+server.delete('time/delete/:id', function(req, res, next) {
 	db.time.remove({
 		id: req.params.id
 	}, function (err, time) {


### PR DESCRIPTION
- Modularized mongo/redis connections in `/dbs/` directory
- Cache time entries in Redis on all relevant path/route handlers
  - Created `refreshEntry` method to save `JSON.stringify`->entries
  - Date/timestamp fields need to be revived via `JSON.parse` upon retrieval from Redis unless/until entire Objects can be stored
- Return POJOs on read via `lean()` & match data structure w/ Redis